### PR TITLE
Make signature parameter type information optional

### DIFF
--- a/docspec-python/src/docspec_python/__init__.py
+++ b/docspec-python/src/docspec_python/__init__.py
@@ -205,7 +205,7 @@ def discover(directory: str) -> Iterable[DiscoveryResult]:
         yield DiscoveryResult.Package(name, os.path.join(directory, name))
 
 
-def format_arglist(args: List[Argument]) -> str:
+def format_arglist(args: List[Argument], include_types: bool = True) -> str:
   """
   Formats a Python argument list.
   """
@@ -217,14 +217,14 @@ def format_arglist(args: List[Argument]) -> str:
     if arg.type == Argument.Type.KeywordOnly and '*' not in result:
       result.append('*')
     parts = [arg.name]
-    if arg.datatype:
+    if arg.datatype and include_types:
       parts.append(': ' + arg.datatype)
     if arg.default_value:
-      if arg.datatype:
+      if arg.datatype and include_types:
         parts.append(' ')
       parts.append('=')
     if arg.default_value:
-      if arg.datatype:
+      if arg.datatype and include_types:
         parts.append(' ')
       parts.append(arg.default_value)
     if arg.type == Argument.Type.PositionalRemainder:


### PR DESCRIPTION
Adds a `include_types` flag to control whether or not type information is added to the `format_arglist` output.

This makes it easier to remove type information when using this function from a subclass of `MarkdownRenderer` in `pydoc-markdown`.

For example, it becomes possible to do this:

```py
  def _format_arglist(self, func: docspec.Function) -> str:
    args = func.args[:]
    if self._is_method(func) and args and args[0].name == 'self':
      args.pop(0)
    return format_arglist(args, include_types=False)
```