### PR TITLE
Visitor pattern implementation

### DIFF
--- a/docspec/src/docspec/__init__.py
+++ b/docspec/src/docspec/__init__.py
@@ -508,12 +508,14 @@ class FilterVisitor(genericvisitor.Visitor[ApiObject]):
     if not self.predicate(ob):
       parent = ob.parent
       if parent is None:
-        raise RuntimeError(f'cannot remove root module, "{ob.full_name}", from the system.')
-      name = ob.name
-      assert isinstance(parent, HasMembers)
+        # Cannot filter out root modules, so we just ignore it. 
+        return
+      
+      # delete the object from the containing list/
+      assert isinstance(parent, (Module, Class))
       assert isinstance(ob, (Data, Function, Class, Module))
       del parent.members[parent.members.index(ob)]
-      assert get_member(parent, name) is None
+      assert get_member(parent, ob.name) is None
 
 class PrintVisitor(genericvisitor.Visitor[ApiObject]):
   """

--- a/docspec/src/docspec/__init__.py
+++ b/docspec/src/docspec/__init__.py
@@ -508,8 +508,7 @@ class FilterVisitor(genericvisitor.Visitor[ApiObject]):
     if not self.predicate(ob):
       parent = ob.parent
       if parent is None:
-        # Cannot filter out root modules, so we just ignore it. 
-        return
+        raise RuntimeError("Cannot filter out root module: '{ob.name}'. ")
       
       # delete the object from the containing list
       assert isinstance(parent, (Module, Class))

--- a/docspec/src/docspec/__init__.py
+++ b/docspec/src/docspec/__init__.py
@@ -513,7 +513,10 @@ class FilterVisitor(genericvisitor.Visitor[ApiObject]):
       
       # delete the object from the containing list/
       assert isinstance(parent, (Module, Class))
-      assert isinstance(ob, (Data, Function, Class, Module))
+      if isinstance(parent, Module):
+        assert isinstance(ob, (Data, Function, Class, Module))
+      else:
+        assert isinstance(ob, (Data, Function, Class))
       del parent.members[parent.members.index(ob)]
       assert get_member(parent, ob.name) is None
 

--- a/docspec/src/docspec/__init__.py
+++ b/docspec/src/docspec/__init__.py
@@ -511,13 +511,12 @@ class FilterVisitor(genericvisitor.Visitor[ApiObject]):
         # Cannot filter out root modules, so we just ignore it. 
         return
       
-      # delete the object from the containing list/
+      # delete the object from the containing list
       assert isinstance(parent, (Module, Class))
-      if isinstance(parent, Module):
-        assert isinstance(ob, (Data, Function, Class, Module))
-      else:
-        assert isinstance(ob, (Data, Function, Class))
-      del parent.members[parent.members.index(ob)]
+      assert isinstance(ob, (Data, Function, Class, Module))
+        
+      del t.cast(t.List[_ModuleMemberType], parent.members)[parent.members.index(ob)]
+      
       assert get_member(parent, ob.name) is None
 
 class PrintVisitor(genericvisitor.Visitor[ApiObject]):

--- a/docspec/src/docspec/__init__.py
+++ b/docspec/src/docspec/__init__.py
@@ -513,8 +513,9 @@ class FilterVisitor(genericvisitor.Visitor[ApiObject]):
       # delete the object from the containing list
       assert isinstance(parent, (Module, Class))
       assert isinstance(ob, (Data, Function, Class, Module))
-        
-      del t.cast(t.List[_ModuleMemberType], parent.members)[parent.members.index(ob)]
+      
+      members = t.cast(t.List[_ModuleMemberType], parent.members)
+      members.remove(ob)
       
       assert get_member(parent, ob.name) is None
 

--- a/docspec/src/docspec/__init__.py
+++ b/docspec/src/docspec/__init__.py
@@ -547,8 +547,8 @@ class PrintVisitor(genericvisitor.Visitor[ApiObject]):
       obj_type = colored(type(ob).__name__, self._COLOR_MAP.get(type(ob))) if self.colorize else type(ob).__name__,
       obj_name = ob.name,
       obj_docstring = ob.docstring or "",
-      obj_lineno = str(ob.location.lineno),
-      obj_filename = ob.location.filename or '',
+      obj_lineno = str(ob.location.lineno) if ob.location else 0,
+      obj_filename = ob.location.filename or '' if ob.location else '',
       )
     print('| ' * depth + self.formatstr.format(**tokens))
   

--- a/docspec/src/docspec/__main__.py
+++ b/docspec/src/docspec/__main__.py
@@ -23,27 +23,8 @@ import argparse
 import docspec
 import sys
 
-try:
-  from termcolor import colored
-except ImportError as exc:
-  def colored(s, *args, **kwargs):  # type: ignore
-    return str(s)
-
-_COLOR_MAP = {
-  docspec.Module: 'magenta',
-  docspec.Class: 'cyan',
-  docspec.Function: 'yellow',
-  docspec.Data: 'blue',
-}
-
-
-def _dump_tree(obj: docspec.ApiObject, depth: int = 0):
-  color = _COLOR_MAP.get(type(obj))
-  type_name = colored(type(obj).__name__.lower(), color)
-  print('| ' * depth + type_name, obj.name)
-  for member in getattr(obj, 'members', []):
-    _dump_tree(member, depth+1)
-
+def _dump_tree(obj: docspec.ApiObject):
+  obj.walk(docspec.PrintVisitor())
 
 def main():
   parser = argparse.ArgumentParser()

--- a/docspec/src/docspec/genericvisitor.py
+++ b/docspec/src/docspec/genericvisitor.py
@@ -1,0 +1,98 @@
+"""
+General purpose visitor pattern implementation. 
+"""
+from typing import Callable, Generic, Iterable, TypeVar
+
+T = TypeVar("T")
+
+# Visitor pattern. This is a mix of ast.NodeVisitor and docutils.nodes.NodeVisitor
+# https://github.com/python/cpython/blob/main/Lib/ast.py#L386
+# https://sourceforge.net/p/docutils/code/HEAD/tree/tags/docutils-0.17.1//docutils/nodes.py#l1968
+
+class Visitor(Generic[T]):
+  """
+  "Visitor" pattern abstract superclass implementation for tree traversals.
+
+  Each class has corresponding methods, doing nothing by
+  default; override individual methods for specific and useful
+  behaviour.  The `visit()` method is called by
+  `walk()` upon entering a object.  `walkabout()` also calls
+  the `depart()` method before exiting a object.
+
+  The generic methods call "``visit_`` + objet class name" or
+  "``depart_`` + objet class name", resp.
+
+  This is a base class for visitors whose ``visit_...`` & ``depart_...``
+  methods should be implemented for *all* concrete objets types encountered. 
+  """
+
+  def visit(self, ob: T) -> None:
+    """Visit an object."""
+    method = 'visit_' + ob.__class__.__name__
+    visitor = getattr(self, method, self.unknown_visit)
+    visitor(ob)
+  
+  def depart(self, ob: T) -> None:
+    """Depart an object."""
+    method = 'depart_' + ob.__class__.__name__
+    visitor = getattr(self, method, self.unknown_departure)
+    visitor(ob)
+  
+  def unknown_visit(self, ob: T) -> None:
+    """
+    Called when entering unknown object types.
+
+    Raise an exception unless overridden.
+    """
+    raise NotImplementedError(
+        '%s visiting unknown object type: %s'
+        % (self.__class__, ob.__class__.__name__))
+
+  def unknown_departure(self, ob: T) -> None:
+    """
+    Called before exiting unknown object types.
+
+    Raise exception unless overridden.
+    """
+    raise NotImplementedError(
+        '%s departing unknown object type: %s'
+        % (self.__class__, ob.__class__.__name__))
+
+def walk(ob: T, visitor: Visitor[T], get_children: Callable[[T], Iterable[T]]) -> None:
+    """
+    Traverse a tree of objects, calling the
+    `visit()` method of `visitor` when entering each
+    node.  (The `walkabout()` method is similar, except it also
+    calls the `depart()` method before exiting each objects.)
+
+    This tree traversal supports limited in-place tree
+    modifications.  Replacing one node with one or more nodes is
+    OK, as is removing an element.  However, if the node removed
+    or replaced occurs after the current node, the old node will
+    still be traversed, and any new nodes will not.
+
+    :param ob: An object to walk.
+    :param visitor: A `Visitor` object, containing a
+        ``visit`` implementation for each object type encountered.
+    :param get_children: A callable that returns the children of an object. 
+    """
+    visitor.visit(ob)
+    children = get_children(ob)
+    for child in children:
+        walk(child, visitor, get_children)
+
+def walkabout(ob: T, visitor: Visitor[T], get_children: Callable[[T], Iterable[T]]) -> None:
+    """
+    Perform a tree traversal similarly to `walk()` (which
+    see), except also call the `depart()` method before exiting each node.
+
+    :param ob: An object to walk.
+    :param visitor: A `Visitor` object, containing a
+        ``visit`` and ``depart`` implementation for each concrete object type encountered.
+    :param get_children: A callable that returns the children of an object. 
+    """
+    visitor.visit(ob)
+    children = get_children(ob)
+    for child in children:
+        walkabout(child, visitor, get_children)
+    visitor.depart(ob)

--- a/docspec/src/test/docspec/test_visitors.py
+++ b/docspec/src/test/docspec/test_visitors.py
@@ -1,0 +1,25 @@
+import docspec
+from .fixtures import module
+
+def test_visitors(capsys, module: docspec.Module) -> None:
+
+    visitor = docspec.PrintVisitor(colorize=False)
+    module.walk(visitor)
+    captured = capsys.readouterr().out
+    assert captured == """:0 - Module: a
+| :0 - Class: foo
+| | :0 - Data: val
+| | :0 - Function: __init__
+"""
+    
+    predicate = lambda ob: not isinstance(ob, docspec.Data) # removes any Data entries
+
+    filter_visitor = docspec.FilterVisitor(predicate)
+    module.walk(filter_visitor)
+    module.walk(visitor)
+    captured = capsys.readouterr().out
+    assert captured == """:0 - Module: a
+| :0 - Class: foo
+| | :0 - Function: __init__
+"""
+


### PR DESCRIPTION
Fixes https://github.com/NiklasRosenstein/docspec/discussions/22

I've created the `PrintVisitor` and the `FilterVisitor` such that you can eventually deprecate `filter_visit()` and/or `visit()` functions. 