### PR TITLE
Add `.modifiers` and `.semantic_hints` to `Data`, `Class` and `Function`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.egg
 build/
 changelog.md
+.vscode/

--- a/docspec-python/setup.py
+++ b/docspec-python/setup.py
@@ -7,12 +7,11 @@ import os
 import setuptools
 import sys
 
-command = sys.argv[1] if len(sys.argv) >= 2 else None
-
 def _tempcopy(src, dst):
   import atexit, shutil
   if not os.path.isfile(dst):
     if not os.path.isfile(src):
+      command = sys.argv[1] if len(sys.argv) >= 2 else None
       msg = '"{}" does not exist, and cannot copy it from "{}" either'.format(dst, src)
       # NOTE: In dist/build commands that are not invoked by Pip, we enforce that the license file
       #       must be present. See https://github.com/NiklasRosenstein/shut/issues/22

--- a/docspec/.changelog/_unreleased.yml
+++ b/docspec/.changelog/_unreleased.yml
@@ -1,6 +1,7 @@
 changes:
 - type: feature
   component: general
-  description: add `Data.modifiers` and `Data.semantic_hints`
+  description: add `Data.modifiers`, `Data.semantic_hints`, `Class.modifiers`, `Class.semantic_hints` and
+    `Function.semantic_hints`
   fixes:
   - '#30'

--- a/docspec/.changelog/_unreleased.yml
+++ b/docspec/.changelog/_unreleased.yml
@@ -1,0 +1,6 @@
+changes:
+- type: feature
+  component: general
+  description: add `Data.modifiers` and `Data.semantic_hints`
+  fixes:
+  - '#30'

--- a/docspec/setup.py
+++ b/docspec/setup.py
@@ -7,12 +7,11 @@ import os
 import setuptools
 import sys
 
-command = sys.argv[1] if len(sys.argv) >= 2 else None
-
 def _tempcopy(src, dst):
   import atexit, shutil
   if not os.path.isfile(dst):
     if not os.path.isfile(src):
+      command = sys.argv[1] if len(sys.argv) >= 2 else None
       msg = '"{}" does not exist, and cannot copy it from "{}" either'.format(dst, src)
       # NOTE: In dist/build commands that are not invoked by Pip, we enforce that the license file
       #       must be present. See https://github.com/NiklasRosenstein/shut/issues/22

--- a/docspec/src/docspec/__init__.py
+++ b/docspec/src/docspec/__init__.py
@@ -250,7 +250,7 @@ class Data(ApiObject):
   #: A list of language-specific modifiers that were used to declare this #Data object.
   modifiers: t.List[str] = dataclasses.field(default_factory=list)
 
-  #: A list of hints that express the semantic of this #Data object that is not otherwise
+  #: A list of hints that express semantics of this #Data object which are not otherwise
   #: derivable from the context.
   semantic_hints: t.List[Semantic] = dataclasses.field(default_factory=list)
 

--- a/docspec/src/docspec/__init__.py
+++ b/docspec/src/docspec/__init__.py
@@ -229,7 +229,7 @@ class Data(ApiObject):
 
   class Semantic(enum.Enum):
     """
-    Describes a semantic property of a #Data object.
+    A list of well-known properties and behaviour that can be attributed to a variable/constant.
     """
 
     #: The #Data object is an instance variable of a class.
@@ -273,6 +273,41 @@ class Function(ApiObject):
   `@property`, `@classmethod` or `@staticmethod`?).
   """
 
+  class Semantic(enum.Enum):
+    """
+    A list of well-known properties and behaviour that can be attributed to a function.
+    """
+
+    #: The function is a coroutine.
+    Coroutine = 0
+
+    #: The function does not return.
+    NoReturn = 1
+
+    #: The function is an instance method.
+    InstanceMethod = 2
+
+    #: The function is a classmethod.
+    ClassMethod = 3
+
+    #: The function is a staticmethod.
+    StaticMethod = 4
+
+    #: The function is a property getter.
+    PropertyGetter = 5
+
+    #: The function is a property setter.
+    PropertySetter = 6
+
+    #: The function is a property deleter.
+    PropertyDelete = 6
+
+    #: The function is abstract.
+    Abstract = 7
+
+    #: The function is final.
+    Final = 8
+
   #: A list of modifiers used in the function definition. For example, the only valid modified in
   #: Python is "async".
   modifiers: t.Optional[t.List[str]]
@@ -285,6 +320,9 @@ class Function(ApiObject):
 
   #: A list of decorations used on the function.
   decorations: t.Optional[t.List[Decoration]]
+
+  #: A list of hints that describe the object.
+  semantic_hints: t.List[Semantic] = dataclasses.field(default_factory=list)
 
 
 class HasMembers(ApiObject):
@@ -307,6 +345,23 @@ class Class(HasMembers):
   Represents a class definition.
   """
 
+  class Semantic(enum.Enum):
+    """
+    A list of well-known properties and behaviour that can be attributed to a class.
+    """
+
+    #: The class describes an interface.
+    Interface = 0
+
+    #: The class is abstract.
+    Abstract = 1
+
+    #: The class is final.
+    Final = 2
+
+    #: The class is an enumeration.
+    Enum = 3
+
   #: The metaclass used in the class definition as a code string.
   metaclass: t.Optional[str]
 
@@ -319,6 +374,12 @@ class Class(HasMembers):
   #: A list of the classes members. #Function#s in a class are to be considered instance methods of
   #: that class unless some information about the #Function indicates otherwise.
   members: t.List['_MemberType']
+
+  #: A list of language-specific modifiers that were used to declare this #Data object.
+  modifiers: t.List[str] = dataclasses.field(default_factory=list)
+
+  #: A list of hints that describe the object.
+  semantic_hints: t.List[Semantic] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass

--- a/docspec/src/docspec/__init__.py
+++ b/docspec/src/docspec/__init__.py
@@ -227,11 +227,32 @@ class Data(ApiObject):
   Represents a variable assignment (e.g. for global variables (often used as constants) or class members).
   """
 
+  class Semantic(enum.Enum):
+    """
+    Describes a semantic property of a #Data object.
+    """
+
+    #: The #Data object is an instance variable of a class.
+    InstanceVariable = 0
+
+    #: The #Data object is a static variable of a class.
+    ClassVariable = 1
+
+    #: The #Data object represents a constant value.
+    Constant = 2
+
   #: The datatype associated with the assignment as code.
   datatype: t.Optional[str] = None
 
   #: The value of the variable as code.
   value: t.Optional[str] = None
+
+  #: A list of language-specific modifiers that were used to declare this #Data object.
+  modifiers: t.List[str] = dataclasses.field(default_factory=list)
+
+  #: A list of hints that express the semantic of this #Data object that is not otherwise
+  #: derivable from the context.
+  semantic_hints: t.List[Semantic] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass

--- a/spec.md
+++ b/spec.md
@@ -92,11 +92,11 @@ _Fields_
 * `name` (str)
 * `location` (str)
 * `docstring` (Optional[Docstring])
-* `modifiers` (Optional[array]) &ndash; An array of `str` representing the modifers of this
+* `modifiers` (Optional[List[str]]) &ndash; An array of `str` representing the modifers of this
   function (e.g. `async`, `classmethod`, etc.).
 * `args` (array) &ndash; An array of `Argument` objects.
 * `return_type` (Optional[str]) &ndash; The return type of the function.
-* `decorations` (Optional[array]) &ndash; An array of `Decoration` objects.
+* `decorations` (Optional[List[str]]) &ndash; An array of `Decoration` objects.
 * `semantic_hints` <sup>(1)</sup> (Optional[List[Function.Semantic]]) &ndash; A list of well-known semantics that
   describe the object. Valid values are `Coroutine`, `NoReturn`, `InstanceMethod`, `ClassMethod`, `StaticMethod`,
   `PropertyGetter`, `PropertySetter`, `PropertyDeleter`, `Abstract`, `Final`.

--- a/spec.md
+++ b/spec.md
@@ -61,6 +61,9 @@ _Fields_
 * `bases` (Optional[array]) &ndash; An array of `str` representing the base classes.
 * `members` (array) &ndash; An array of `Data`, `Function` or `Class` objects.
 * `decorations` (Optional[array]) &ndash; An array of `Decoration` objects.
+* `modifiers` (Optional[List[str]]) &ndash; A list of modifiers used to declare the class.
+* `semantic_hints` <sup>(1)</sup> (Optional[List[Class.Semantic]]) &ndash; A list of well-known semantics that describe the object.
+  Valid values are `Interface`, `Abstract`, `Final`, `Enum`.
 
 ### Data
 
@@ -75,9 +78,9 @@ _Fields_
 * `datatype` (Optional[str]) &ndash; The datatype of the value.
 * `value` (Optional[str]) &ndash; The value in the form of the definition
   in the source.
-* `modifiers` (List[str]) &ndash; A list of modifiers used to declare the this object.
-* `semantic_hints` (List[Semantic]) &ndash; A list of well-known `Semantic`s that describe the object beyond
-  what is derivable from the context. Valid values are `InstanceVariable`, `ClassVariable` and `Constant`.
+* `modifiers` (Optional[List[str]]) &ndash; A list of modifiers used to declare the this object.
+* `semantic_hints` <sup>(1)</sup> (Optional[List[Data.Semantic]]) &ndash; A list of well-known semantics that describe
+  the object. Valid values are `InstanceVariable`, `ClassVariable` and `Constant`.
 
 ### Function
 
@@ -94,6 +97,9 @@ _Fields_
 * `args` (array) &ndash; An array of `Argument` objects.
 * `return_type` (Optional[str]) &ndash; The return type of the function.
 * `decorations` (Optional[array]) &ndash; An array of `Decoration` objects.
+* `semantic_hints` <sup>(1)</sup> (Optional[List[Function.Semantic]]) &ndash; A list of well-known semantics that
+  describe the object. Valid values are `Coroutine`, `NoReturn`, `InstanceMethod`, `ClassMethod`, `StaticMethod`,
+  `PropertyGetter`, `PropertySetter`, `PropertyDeleter`, `Abstract`, `Final`.
 
 ### Argument
 
@@ -130,6 +136,16 @@ _Fields_
 * `target` (str) &ndash; The target name of the indirection
 * `location` (Location)
 * `docstring` (Optional[Docstring])
+
+### _Footnotes_
+
+<sup>(1) About `semantic_hints`: Semantic hints are intended to describe facets of an API object that are well-known
+natural properties of the programming language. Sometimes those hints are not otherwise derivable from the surrounding
+API object tree, and sometimes the information may appears duplicated. (Example: In Python, a class that can be
+considered an interface might inherit from `typing.Protocol` or be implemented as a `zope.interface`, thus the
+information would also be available through `Class.bases`. In Java, an interface has the `interface` as an entry in
+the `Class.modifiers`). The extend to which the semantic hints are complete or correct depends entirely on the
+docspec loader.</sup>
 
 ---
 

--- a/spec.md
+++ b/spec.md
@@ -75,6 +75,9 @@ _Fields_
 * `datatype` (Optional[str]) &ndash; The datatype of the value.
 * `value` (Optional[str]) &ndash; The value in the form of the definition
   in the source.
+* `modifiers` (List[str]) &ndash; A list of modifiers used to declare the this object.
+* `semantic_hints` (List[Semantic]) &ndash; A list of well-known `Semantic`s that describe the object beyond
+  what is derivable from the context. Valid values are `InstanceVariable`, `ClassVariable` and `Constant`.
 
 ### Function
 


### PR DESCRIPTION
Closes #30

I found the `semantic_hints` concept quite compelling to represent numerous aspects of variables/constants, functions and classes. Docspec ultimately should be able to represent a superset of common concepts in various programming languages (though right now it is still very Python-centric).
