### PR TITLE
Rename enum values to `UPPER_CASE`

### DIFF
--- a/docspec-python/src/docspec_python/__init__.py
+++ b/docspec-python/src/docspec_python/__init__.py
@@ -228,7 +228,7 @@ def format_arglist(args: t.List[Argument]) -> str:
 
   for arg in args:
     parts = []
-    if arg.type == Argument.Type.KeywordOnly and '*' not in result:
+    if arg.type == Argument.Type.KEYWORD_ONLY and '*' not in result:
       result.append('*')
     parts = [arg.name]
     if arg.datatype:
@@ -241,9 +241,9 @@ def format_arglist(args: t.List[Argument]) -> str:
       if arg.datatype:
         parts.append(' ')
       parts.append(arg.default_value)
-    if arg.type == Argument.Type.PositionalRemainder:
+    if arg.type == Argument.Type.POSITIONAL_REMAINDER:
       parts.insert(0, '*')
-    elif arg.type == Argument.Type.KeywordRemainder:
+    elif arg.type == Argument.Type.KEYWORD_REMAINDER:
       parts.insert(0, '**')
     result.append(''.join(parts))
 

--- a/docspec-python/src/docspec_python/parser.py
+++ b/docspec-python/src/docspec_python/parser.py
@@ -313,15 +313,15 @@ class Parser:
       tname = find(lambda x: x.type == syms.tname, parameters.children)
       if tname:
         scanner = ListScanner(parameters.children, parameters.children.index(tname))
-        result.append(self.parse_argument(tname, Argument.Type.Positional, scanner))
+        result.append(self.parse_argument(tname, Argument.Type.POSITIONAL, scanner))
       else:
         # This must be either ["(", ")"] or ["(", "argname", ")"].
         assert len(parameters.children) in (2, 3), parameters.children
         if len(parameters.children) == 3:
-          result.append(Argument(parameters.children[1].value, Argument.Type.Positional, None, None, None))
+          result.append(Argument(parameters.children[1].value, Argument.Type.POSITIONAL, None, None, None))
       return result
 
-    argtype = Argument.Type.Positional
+    argtype = Argument.Type.POSITIONAL
 
     index = ListScanner(arglist.children)
     for node in index.safe_iter(auto_advance=False):
@@ -329,13 +329,13 @@ class Parser:
       if node.type == token.STAR:
         node = index.advance()
         if node.type != token.COMMA:
-          result.append(self.parse_argument(node, Argument.Type.PositionalRemainder, index))
+          result.append(self.parse_argument(node, Argument.Type.POSITIONAL_REMAINDER, index))
         index.advance()
-        argtype = Argument.Type.KeywordOnly
+        argtype = Argument.Type.KEYWORD_ONLY
         continue
       elif node.type == token.DOUBLESTAR:
         node = index.advance()
-        result.append(self.parse_argument(node, Argument.Type.KeywordRemainder, index))
+        result.append(self.parse_argument(node, Argument.Type.KEYWORD_REMAINDER, index))
         continue
       result.append(self.parse_argument(node, argtype, index))
       index.advance()

--- a/docspec-python/src/test/test_parser.py
+++ b/docspec-python/src/test/test_parser.py
@@ -95,9 +95,9 @@ def test_funcdef_2():
       docstring=Docstring('This uses annotations and keyword-only arguments.', Location('test_funcdef_2', 2)),
       modifiers=None,
       args=[
-        Argument('a', Argument.Type.Positional, None, 'int', None),
-        Argument('c', Argument.Type.KeywordOnly, None, 'str', None),
-        Argument('opts', Argument.Type.KeywordRemainder, None, 'Any', None),
+        Argument('a', Argument.Type.POSITIONAL, None, 'int', None),
+        Argument('c', Argument.Type.KEYWORD_ONLY, None, 'str', None),
+        Argument('opts', Argument.Type.KEYWORD_REMAINDER, None, 'Any', None),
       ],
       return_type='None',
       decorations=[],
@@ -121,11 +121,11 @@ def test_funcdef_3():
       docstring=Docstring('More arg variations.', Location('test_funcdef_3', 4)),
       modifiers=None,
       args=[
-        Argument('self', Argument.Type.Positional, None, None, None),
-        Argument('a', Argument.Type.Positional, None, 'int', None),
-        Argument('b', Argument.Type.Positional, None, None, None),
-        Argument('args', Argument.Type.PositionalRemainder, None, None, None),
-        Argument('opt', Argument.Type.KeywordOnly, None, 'str', None),
+        Argument('self', Argument.Type.POSITIONAL, None, None, None),
+        Argument('a', Argument.Type.POSITIONAL, None, 'int', None),
+        Argument('b', Argument.Type.POSITIONAL, None, None, None),
+        Argument('args', Argument.Type.POSITIONAL_REMAINDER, None, None, None),
+        Argument('opt', Argument.Type.KEYWORD_ONLY, None, 'str', None),
       ],
       return_type='Optional[int]',
       decorations=[
@@ -150,9 +150,9 @@ def test_funcdef_4():
       docstring=None,
       modifiers=None,
       args=[
-        Argument('project_name', Argument.Type.Positional, None, None, None),
-        Argument('project_type', Argument.Type.Positional, None, None, None),
-        Argument('port', Argument.Type.Positional, None, None, '8001'),
+        Argument('project_name', Argument.Type.POSITIONAL, None, None, None),
+        Argument('project_type', Argument.Type.POSITIONAL, None, None, None),
+        Argument('port', Argument.Type.POSITIONAL, None, None, '8001'),
       ],
       return_type=None,
       decorations=[],
@@ -189,7 +189,7 @@ def test_funcdef_5_single_stmt():
       location=None,
       docstring=Docstring(docstring, Location('test_funcdef_5_single_stmt', lineno)) if docstring else None,
       modifiers=None,
-      args=[Argument('self', Argument.Type.Positional, None, None, None)],
+      args=[Argument('self', Argument.Type.POSITIONAL, None, None, None)],
       return_type=None,
       decorations=[],
     )
@@ -234,23 +234,23 @@ def test_funcdef_6_starred_args():
 
   return [
     mkfunc('func1', None, 0, [
-      Argument('a', Argument.Type.Positional, None, None, None),
-      Argument('b', Argument.Type.KeywordOnly, None, None, None),
-      Argument('c', Argument.Type.KeywordRemainder, None, None, None),
+      Argument('a', Argument.Type.POSITIONAL, None, None, None),
+      Argument('b', Argument.Type.KEYWORD_ONLY, None, None, None),
+      Argument('c', Argument.Type.KEYWORD_REMAINDER, None, None, None),
     ]),
     mkfunc('func2', 'Docstring goes here.', 4, [
-      Argument('args', Argument.Type.PositionalRemainder, None, None, None),
-      Argument('kwargs', Argument.Type.KeywordRemainder, None, None, None),
+      Argument('args', Argument.Type.POSITIONAL_REMAINDER, None, None, None),
+      Argument('kwargs', Argument.Type.KEYWORD_REMAINDER, None, None, None),
     ]),
     mkfunc('func3', 'Docstring goes here.', 7, [
-      Argument('kwargs', Argument.Type.KeywordRemainder, None, None, None),
+      Argument('kwargs', Argument.Type.KEYWORD_REMAINDER, None, None, None),
     ]),
     mkfunc('func4', 'Docstring goes here', 10, [
-      Argument('abc', Argument.Type.Positional, None, None, None),
+      Argument('abc', Argument.Type.POSITIONAL, None, None, None),
     ]),
     mkfunc('func5', 'Docstring goes here', 13, [
-      Argument('abc', Argument.Type.Positional, None, None, None),
-      Argument('kwonly', Argument.Type.KeywordOnly, None, None, None),
+      Argument('abc', Argument.Type.POSITIONAL, None, None, None),
+      Argument('kwonly', Argument.Type.KEYWORD_ONLY, None, None, None),
     ]),
   ]
 

--- a/docspec/.changelog/_unreleased.yml
+++ b/docspec/.changelog/_unreleased.yml
@@ -1,7 +1,13 @@
 changes:
 - type: feature
   component: general
-  description: add `Data.modifiers`, `Data.semantic_hints`, `Class.modifiers`, `Class.semantic_hints` and
-    `Function.semantic_hints`
+  description: add `Data.modifiers`, `Data.semantic_hints`, `Class.modifiers`, `Class.semantic_hints`
+    and `Function.semantic_hints`
   fixes:
   - '#30'
+- type: change
+  component: general
+  description: rename `Argument.Type` enumeration values to `UPPER_CASE` format according
+    to latest specification (full backwards compatibility, including deserializing
+    JSON payloads with the old argument type names)
+  fixes: []

--- a/docspec/package.yml
+++ b/docspec/package.yml
@@ -13,6 +13,7 @@ requirements:
 test-requirements:
 - types-Deprecated
 - types-termcolor
+- databind.core ^1.2.1
 test-drivers:
 - type: pytest
 - type: mypy

--- a/docspec/setup.py
+++ b/docspec/setup.py
@@ -41,6 +41,7 @@ requirements = [
 test_requirements = [
   'types-Deprecated',
   'types-termcolor',
+  'databind.core >=1.2.1,<2.0.0',
 ]
 extras_require = {}
 extras_require['test'] = test_requirements

--- a/docspec/src/docspec/__init__.py
+++ b/docspec/src/docspec/__init__.py
@@ -52,8 +52,8 @@ import typing_extensions as te
 import weakref
 
 import deprecated
-import databind.core.annotations as A
 import databind.json
+from databind.core.annotations import alias, union
 
 
 @dataclasses.dataclass
@@ -410,15 +410,14 @@ class Module(HasMembers):
 _Members = t.Union[Data, Function, Class, Indirection]
 _MemberType = te.Annotated[
   _Members,
-  A.unionclass({ 'data': Data, 'function': Function, 'class': Class, 'indirection': Indirection },
-    style=A.unionclass.Style.flat)]
+  union({ 'data': Data, 'function': Function, 'class': Class, 'indirection': Indirection }, style=union.Style.flat)]
 
 
 _ModuleMembers = t.Union[Data, Function, Class, Module, Indirection]
 _ModuleMemberType = te.Annotated[
   _ModuleMembers,
-  A.unionclass({ 'data': Data, 'function': Function, 'class': Class, 'module': Module, 'indirection': Indirection },
-    style=A.unionclass.Style.flat)]
+  union({ 'data': Data, 'function': Function, 'class': Class, 'module': Module, 'indirection': Indirection },
+    style=union.Style.flat)]
 
 
 def load_module(

--- a/docspec/src/docspec/__init__.py
+++ b/docspec/src/docspec/__init__.py
@@ -118,20 +118,20 @@ class Argument:
     """
 
     #: A positional only argument. Such arguments are denoted in Python like this: `def foo(a, b, /): ...`
-    POSITIONAL_ONLY = 0
+    POSITIONAL_ONLY: te.Annotated[int, alias('POSITIONAL_ONLY', 'PositionalOnly')] = 0
 
     #: A positional argument, which may also be given as a keyword argument. Basically that is just a normal
     #: argument as you would see most commonly in Python function definitions.
-    POSITIONAL = 1
+    POSITIONAL: te.Annotated[int, alias('POSITIONAL', 'Positional')] = 1
 
     #: An argument that denotes the capture of additional positional arguments, aka. "args" or "varags".
-    POSITIONAL_REMAINDER = 2
+    POSITIONAL_REMAINDER: te.Annotated[int, alias('POSITIONAL_REMAINDER', 'PositionalRemainder')] = 2
 
     #: A keyword-only argument is denoted in Python like thisL `def foo(*, kwonly): ...`
-    KEYWORD_ONLY = 3
+    KEYWORD_ONLY: te.Annotated[int, alias('KEYWORD_ONLY', 'KeywordOnly')] = 3
 
     #: An argument that captures additional keyword arguments, aka. "kwargs".
-    KEYWORD_REMAINDER = 4
+    KEYWORD_REMAINDER: te.Annotated[int, alias('KEYWORD_REMAINDER', 'KeywordRemainder')] = 4
 
     # backwards compatibility, < 1.2.0
     PositionalOnly: t.ClassVar['Argument.Type']

--- a/docspec/src/docspec/__init__.py
+++ b/docspec/src/docspec/__init__.py
@@ -118,20 +118,33 @@ class Argument:
     """
 
     #: A positional only argument. Such arguments are denoted in Python like this: `def foo(a, b, /): ...`
-    PositionalOnly = 0
+    POSITIONAL_ONLY = 0
 
     #: A positional argument, which may also be given as a keyword argument. Basically that is just a normal
     #: argument as you would see most commonly in Python function definitions.
-    Positional = 1
+    POSITIONAL = 1
 
     #: An argument that denotes the capture of additional positional arguments, aka. "args" or "varags".
-    PositionalRemainder = 2
+    POSITIONAL_REMAINDER = 2
 
     #: A keyword-only argument is denoted in Python like thisL `def foo(*, kwonly): ...`
-    KeywordOnly = 3
+    KEYWORD_ONLY = 3
 
     #: An argument that captures additional keyword arguments, aka. "kwargs".
-    KeywordRemainder = 4
+    KEYWORD_REMAINDER = 4
+
+    # backwards compatibility, < 1.2.0
+    PositionalOnly: t.ClassVar['Argument.Type']
+    Positional: t.ClassVar['Argument.Type']
+    PositionalRemainder: t.ClassVar['Argument.Type']
+    KeywordOnly: t.ClassVar['Argument.Type']
+    KeywordRemainder: t.ClassVar['Argument.Type']
+
+  Type.PositionalOnly = Type.POSITIONAL_ONLY
+  Type.Positional = Type.POSITIONAL
+  Type.PositionalRemainder = Type.POSITIONAL_REMAINDER
+  Type.KeywordOnly = Type.KEYWORD_ONLY
+  Type.KeywordRemainder = Type.KEYWORD_REMAINDER
 
   #: The name of the argument.
   name: str
@@ -233,13 +246,13 @@ class Data(ApiObject):
     """
 
     #: The #Data object is an instance variable of a class.
-    InstanceVariable = 0
+    INSTANCE_VARIABLE = 0
 
     #: The #Data object is a static variable of a class.
-    ClassVariable = 1
+    CLASS_VARIABLE = 1
 
     #: The #Data object represents a constant value.
-    Constant = 2
+    CONSTANT = 2
 
   #: The datatype associated with the assignment as code.
   datatype: t.Optional[str] = None
@@ -278,35 +291,35 @@ class Function(ApiObject):
     A list of well-known properties and behaviour that can be attributed to a function.
     """
 
-    #: The function is a coroutine.
-    Coroutine = 0
-
-    #: The function does not return.
-    NoReturn = 1
-
-    #: The function is an instance method.
-    InstanceMethod = 2
-
-    #: The function is a classmethod.
-    ClassMethod = 3
-
-    #: The function is a staticmethod.
-    StaticMethod = 4
-
-    #: The function is a property getter.
-    PropertyGetter = 5
-
-    #: The function is a property setter.
-    PropertySetter = 6
-
-    #: The function is a property deleter.
-    PropertyDelete = 6
-
     #: The function is abstract.
-    Abstract = 7
+    ABSTRACT = 0
 
     #: The function is final.
-    Final = 8
+    FINAL = 1
+
+    #: The function is a coroutine.
+    COROUTINE = 2
+
+    #: The function does not return.
+    NO_RETURN = 3
+
+    #: The function is an instance method.
+    INSTANCE_METHOD = 4
+
+    #: The function is a classmethod.
+    CLASS_METHOD = 5
+
+    #: The function is a staticmethod.
+    STATIC_METHOD = 6
+
+    #: The function is a property getter.
+    PROPERTY_GETTER = 7
+
+    #: The function is a property setter.
+    PROPERTY_SETTER = 8
+
+    #: The function is a property deleter.
+    PROPERTY_DELETER = 9
 
   #: A list of modifiers used in the function definition. For example, the only valid modified in
   #: Python is "async".
@@ -351,16 +364,16 @@ class Class(HasMembers):
     """
 
     #: The class describes an interface.
-    Interface = 0
+    INTERFACE = 0
 
     #: The class is abstract.
-    Abstract = 1
+    ABSTRACT = 1
 
     #: The class is final.
-    Final = 2
+    FINAL = 2
 
     #: The class is an enumeration.
-    Enum = 3
+    ENUM = 3
 
   #: The metaclass used in the class definition as a code string.
   metaclass: t.Optional[str]

--- a/docspec/src/test/docspec/fixtures.py
+++ b/docspec/src/test/docspec/fixtures.py
@@ -9,7 +9,7 @@ def module() -> docspec.Module:
     docspec.Class('foo', None, docspec.Docstring('This is class foo.', None), None, None, None, [
       docspec.Data('val', None, None, 'int', '42'),
       docspec.Function('__init__', None, None, None, [
-        docspec.Argument('self', docspec.Argument.Type.Positional, None, None, None)
+        docspec.Argument('self', docspec.Argument.Type.POSITIONAL, None, None, None)
       ], None, None),
     ]),
   ])
@@ -24,7 +24,7 @@ def typed_module() -> docspec.Module:
     docspec.Class('foo', docspec.Location('test.py', 2), docspec.Docstring('This is class foo.', docspec.Location('test.py', 3)), None, None, None, [
       docspec.Data('val', docspec.Location('test.py', 4), None, 'Union[int, float]', '42'),
       docspec.Function('__init__', docspec.Location('test.py', 5), None, None, [
-        docspec.Argument('self', docspec.Argument.Type.Positional, None, None, None)
+        docspec.Argument('self', docspec.Argument.Type.POSITIONAL, None, None, None)
       ], None, None),
     ]),
   ])

--- a/docspec/src/test/docspec/test_deserialize.py
+++ b/docspec/src/test/docspec/test_deserialize.py
@@ -4,6 +4,7 @@ import typing as t
 import weakref
 from .fixtures import module, typed_module
 
+
 def test_serialize_typed(typed_module: docspec.Module):
   assert docspec.dump_module(typed_module) == {
     'docstring': None,
@@ -28,7 +29,7 @@ def test_serialize_typed(typed_module: docspec.Module):
                               'type': 'data',
                               'value': '42'},
                               {'args': [{'name': 'self',
-                                        'type': 'Positional'}],
+                                        'type': 'POSITIONAL'}],
                               'decorations': None,
                               'docstring': None,
                               'location': {'filename': 'test.py',
@@ -42,6 +43,7 @@ def test_serialize_typed(typed_module: docspec.Module):
                   'type': 'class'}],
     'name': 'a',
   }
+
 
 def test_serialize(module: docspec.Module):
   assert docspec.dump_module(module) == {
@@ -75,7 +77,7 @@ def test_serialize(module: docspec.Module):
             'args': [
               {
                 'name': 'self',
-                'type': 'Positional',
+                'type': 'POSITIONAL',
               }
             ],
             'return_type': None,

--- a/docspec/src/test/docspec/test_deserialize.py
+++ b/docspec/src/test/docspec/test_deserialize.py
@@ -115,3 +115,51 @@ def test_serialize_deserialize(module: docspec.Module):
         _deep_comparison(a[i], b[i], path + [i], seen)
 
   _deep_comparison(deser, module, ['$'], set())
+
+
+def test_deserialize_old_function_argument_types():
+  payload = {
+    'name': 'a',
+    'location': None,
+    'docstring': None,
+    'members': [
+      {
+        'type': 'function',
+        'name': 'bar',
+        'location': None,
+        'docstring': None,
+        'modifiers': None,
+        'return_type': None,
+        'decorations': None,
+        'args': [
+          {
+            'name': 'n',
+            'datatype': 'int',
+            'type': 'Positional'
+          }
+        ]
+      }
+    ]
+  }
+  assert docspec.load_module(payload) == docspec.Module(
+    name='a',
+    location=None,
+    docstring=None,
+    members=[
+      docspec.Function(
+        name='bar',
+        location=None,
+        docstring=None,
+        modifiers=None,
+        return_type=None,
+        decorations=None,
+        args=[
+          docspec.Argument(
+            name='n',
+            datatype='int',
+            type=docspec.Argument.Type.POSITIONAL
+          )
+        ]
+      )
+    ]
+  )


### PR DESCRIPTION
Follow up to #30  and #38. Upper-case enumeration value names make more sense.

The change to the value names in `Argument.Type` is fully backwards compatible (incl. Json deserialization of payloads with old value names).