### PR TITLE
remove `Decoration.name_expression` again because `Decoration.name` is sufficient

### DIFF
--- a/.changelog/_unreleased.yml
+++ b/.changelog/_unreleased.yml
@@ -1,6 +1,0 @@
-changes:
-- type: feature
-  component: general
-  description: add `Decoration.name_expression` field, `Decoration.name` is now optional
-    (i.e. nullable)
-  fixes: []

--- a/docspec/src/docspec/__init__.py
+++ b/docspec/src/docspec/__init__.py
@@ -100,16 +100,13 @@ class Decoration:
   Represents a decorator on a #Class or #Function.
   """
 
-  #: The name of the decorator (i.e. the text between the `@` and `(`).
+  #: The name of the decorator (i.e. the text between the `@` and `(`). In languages that support it,
+  #: this may be a piece of code.
   name: t.Optional[str]
 
   #: Decorator arguments as plain code (including the leading and trailing parentheses). This is
   #: `None` when the decorator does not have call arguments.
   args: t.Optional[str] = None
-
-  #: This field should be used instead of #name if the decorator is not just a simple name but
-  #: a complex expression.
-  name_expression: t.Optional[str] = None
 
   #: The location of the decoration in the source code.
   location: t.Optional[Location] = None

--- a/docspec/src/specification.yml
+++ b/docspec/src/specification.yml
@@ -136,24 +136,16 @@ Decoration:
   docs: Represents a decoration that can be applied to a function or class.
   fields:
     name:
-      type: Optional[str]
-      docs: The name of the decorator used in this decoration. This may be `null` if the decorator
-        can not be represented simply by a name, e.g. in Python 3.9 where decorators can be full
-        fledged expressions. In that case the `name_expression` field is used instead.
+      type: str
+      docs: The name of the decorator used in this decoration. This may be a piece of code in languages
+        that support complex decoration syntax. (e.g. in Python, `@(decorator_factory().dec)(a, b, c)` should
+        be represented as `"(decorator_factory().dec)"` for the `name` and `["a", "b", "c"]` for the `args`).
     args:
       type: Optional[List[str]]
       required: false
       docs: A list of the raw source code for each argument of the decorator. If this is not set,
         that means the decorator is not called. If the list is empty, the decorator is called without
         arguments.
-    name_expression:
-      type: Optional[List[str]]
-      required: false
-      docs: The raw code string that represents the decorator that is used for this expression. This
-        is used if the decorator can not be represented by just a `name`. The `args` may still be used
-        if the expression gets called (e.g. in the case of `@(decorator_factory().dec)(a, b, c)`, the
-        `name_expression` should be `"(decorator_factory().dec)"` whereas the `args` should be
-        `["a", "b", "c"]`.
     location:
       type: Optional[List[str]]
       required: false


### PR DESCRIPTION

Having just the `Decoration.name` field should be enough if the `name` can also be an expression.

| Code | `Decorator.name` | `Decorator.args` | Notes |
| --- | --- | --- | --- |
| `@property` | `"property"` | `null` | |
| `@functools.lru_cache(max_size=10)` | `"functools.lru_cache"` | `["max_size=10"]` | |
| `@dec['name']` | `"dec['name']"` | `null` | since Python 3.9 |
| `@(decorators().name)(a, b=c)` | `"(decorators().name)"` | `["a", "b=c"]` | since Python 3.9 |
