### PR TITLE
improvement: Bump black to >=23.1.0

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[entries]]
+id = "7e6f481f-0e4b-4502-981c-cf98a757dd6d"
+type = "improvement"
+description = "Bump black to `>=23.1.0`"
+author = "@mcintel"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,14 +24,14 @@ jobs:
     - run: slap install --only ${{ matrix.project }} --no-venv-check -v
     - run: DOCSPEC_TEST_NO_DEVELOP=true slap test ${{ matrix.project }}
 
-  changelog-update:
-    name: "Insert the Pull Request URL into new changelog entries"
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v2
-      - uses: NiklasRosenstein/slap@gha/changelog/update/v2
-        with: { version: '*' }
+  # changelog-update:
+  #   name: "Insert the Pull Request URL into new changelog entries"
+  #   runs-on: ubuntu-latest
+  #   if: github.event_name == 'pull_request'
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - uses: NiklasRosenstein/slap@gha/changelog/update/v2
+  #       with: { version: '*' }
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.x"]
+        python-version: ["3.8", "3.9", "3.10", "3.x"]
         project: ["docspec", "docspec-python"]
     steps:
     - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 build/
 .vscode/
 .python-version
+docs/_site
 
 # Generate files for documentation.
 changelog.md

--- a/docspec-python/pyproject.toml
+++ b/docspec-python/pyproject.toml
@@ -17,7 +17,7 @@ packages = [{ include = "docspec_python", from="src" }]
 python = "^3.7"
 docspec = "^2.2.1"
 "nr.util" = ">=0.7.0"
-black = ">=23.1.0"
+black = "^24.4.2"
 
 [tool.poetry.dev-dependencies]
 black = "*"

--- a/docspec-python/pyproject.toml
+++ b/docspec-python/pyproject.toml
@@ -14,7 +14,7 @@ homepage = "https://github.com/NiklasRosenstein/docspec/"
 packages = [{ include = "docspec_python", from="src" }]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 docspec = "^2.2.1"
 "nr.util" = ">=0.7.0"
 black = "^24.4.2"

--- a/docspec-python/pyproject.toml
+++ b/docspec-python/pyproject.toml
@@ -17,7 +17,7 @@ packages = [{ include = "docspec_python", from="src" }]
 python = "^3.7"
 docspec = "^2.2.1"
 "nr.util" = ">=0.7.0"
-black = "^23.1.0"
+black = ">=23.1.0"
 
 [tool.poetry.dev-dependencies]
 black = "*"

--- a/docspec-python/src/docspec_python/__init__.py
+++ b/docspec-python/src/docspec_python/__init__.py
@@ -91,24 +91,22 @@ def load_python_modules(
 
 
 @t.overload
-def parse_python_module(
+def parse_python_module(  # noqa
     filename: t.Union[str, Path],
     module_name: t.Optional[str] = None,
     options: t.Optional[ParserOptions] = None,
     encoding: t.Optional[str] = None,
-) -> Module:
-    ...
+) -> Module: ...
 
 
 @t.overload
-def parse_python_module(
+def parse_python_module(  # noqa
     fp: t.TextIO,
     filename: t.Union[str, Path],
     module_name: t.Optional[str] = None,
     options: t.Optional[ParserOptions] = None,
     encoding: t.Optional[str] = None,
-) -> Module:
-    ...
+) -> Module: ...
 
 
 def parse_python_module(  # type: ignore

--- a/docspec-python/src/docspec_python/parser.py
+++ b/docspec-python/src/docspec_python/parser.py
@@ -107,18 +107,15 @@ V = t.TypeVar("V")
 
 
 @t.overload
-def find(predicate: t.Callable[[T], t.Any], iterable: t.Iterable[T], as_type: None = None) -> T | None:
-    ...
+def find(predicate: t.Callable[[T], t.Any], iterable: t.Iterable[T], as_type: None = None) -> T | None: ...  # noqa
 
 
 @t.overload
-def find(predicate: t.Callable[[T], t.Any], iterable: t.Iterable[T], as_type: type[V]) -> V | None:
-    ...
+def find(predicate: t.Callable[[T], t.Any], iterable: t.Iterable[T], as_type: type[V]) -> V | None: ...  # noqa
 
 
 @t.overload
-def find(predicate: None, iterable: t.Iterable[T], as_type: type[V]) -> V | None:
-    ...
+def find(predicate: None, iterable: t.Iterable[T], as_type: type[V]) -> V | None: ...  # noqa
 
 
 def find(
@@ -149,13 +146,11 @@ def find(
 
 
 @t.overload
-def get(predicate: t.Callable[[T], object], iterable: t.Iterable[T], as_type: None = None) -> T:
-    ...
+def get(predicate: t.Callable[[T], object], iterable: t.Iterable[T], as_type: None = None) -> T: ...  # noqa
 
 
 @t.overload
-def get(predicate: t.Callable[[T], object], iterable: t.Iterable[T], as_type: type[V]) -> V:
-    ...
+def get(predicate: t.Callable[[T], object], iterable: t.Iterable[T], as_type: type[V]) -> V: ...  # noqa
 
 
 def get(predicate: t.Callable[[T], object], iterable: t.Iterable[T], as_type: type[V] | None = None) -> T | V:

--- a/docspec/pyproject.toml
+++ b/docspec/pyproject.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/NiklasRosenstein/docspec/"
 packages = [{include="docspec", from="src"}]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 "databind.core" = "^4.2.6"
 "databind.json" = "^4.2.6"
 Deprecated = "^1.2.12"

--- a/docspec/src/docspec/__init__.py
+++ b/docspec/src/docspec/__init__.py
@@ -515,17 +515,15 @@ def load_modules(
 
 
 @t.overload
-def dump_module(
+def dump_module(  # noqa
     module: Module, target: t.Union[str, t.IO[str]], dumper: t.Callable[[t.Any, t.IO[str]], None] = json.dump
-) -> None:
-    ...
+) -> None: ...
 
 
 @t.overload
-def dump_module(
+def dump_module(  # noqa
     module: Module, target: None = None, dumper: t.Callable[[t.Any, t.IO[str]], None] = json.dump
-) -> t.Dict[str, t.Any]:
-    ...
+) -> t.Dict[str, t.Any]: ...
 
 
 def dump_module(

--- a/docspec/src/docspec/__main__.py
+++ b/docspec/src/docspec/__main__.py
@@ -25,7 +25,7 @@ import sys
 import docspec
 
 try:
-    from termcolor import colored  # type: ignore
+    from termcolor import colored
 except ImportError:
 
     def colored(s, *args, **kwargs):  # type: ignore

--- a/docspec/src/docspec/__main__.py
+++ b/docspec/src/docspec/__main__.py
@@ -25,7 +25,7 @@ import sys
 import docspec
 
 try:
-    from termcolor import colored
+    from termcolor import colored  # type: ignore
 except ImportError:
 
     def colored(s, *args, **kwargs):  # type: ignore

--- a/docspec/test/docspec/test_deserialize.py
+++ b/docspec/test/docspec/test_deserialize.py
@@ -92,7 +92,7 @@ def test_serialize_deserialize(module: docspec.Module) -> None:
     assert deser == module
 
     def _deep_comparison(a: t.Any, b: t.Any, path: list[str | int], seen: set[int]) -> None:
-        assert type(a) == type(b), path
+        assert isinstance(a, type(b)), path
         if isinstance(a, weakref.ref):
             a, b = a(), b()
             assert a == b, path

--- a/slap.toml
+++ b/slap.toml
@@ -6,4 +6,4 @@ enabled = false
 "docs:dev" = "cd docs && novella --serve"
 
 [install.extras]
-docs = ["mako", "mkdocs", "mkdocs-material", "novella==0.1.15", "pydoc-markdown==4.6.0", "databind ^1.5.0"]
+docs = ["mako", "mkdocs", "mkdocs-material", "novella==0.1.15", "pydoc-markdown >=4.6.0", "databind >=1.5.0"]


### PR DESCRIPTION
Along with this, also needed to bump pydoc-markdown. And for good measure, added docs/_site to .gitignore so `slap run docs:build` won't show a bunch of new files to add.