### PR TITLE
Update nr.util import in pyproject.toml

### DIFF
--- a/docspec-python/pyproject.toml
+++ b/docspec-python/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.8"
 dependencies = [
     "black>=24.8.0",
     "docspec==2.2.1",
-    "nr-util>=0.8.12",
+    "nr.util>=0.8.12",
 ]
 authors = [{ name = "Niklas Rosenstein", email = "rosensteinniklas@gmail.com" }]
 


### PR DESCRIPTION
When `nr.util` is specified as `nr-util` it causes import failures in a few envs. This PR might need more testing!