### PR TITLE
feat: add support for .pyi stub files in iter_package_files and discover

### DIFF
--- a/docspec-python/src/docspec_python/__init__.py
+++ b/docspec-python/src/docspec_python/__init__.py
@@ -190,7 +190,7 @@ def iter_package_files(
         if not parent_dir.is_dir():
             continue
         for item in recurse_directory(parent_dir):
-            if item.suffix == ".py":
+            if item.suffix in (".py", ".pyi"):
                 parts = item.with_suffix("").relative_to(parent_dir).parts
                 if parts[-1] == "__init__":
                     parts = parts[:-1]
@@ -235,8 +235,9 @@ def discover(directory: t.Union[str, Path]) -> t.Iterable[DiscoveryResult]:
     #   if we're looking at a namespace package. If we do, continue recursively.
 
     for name in os.listdir(directory):
-        if name.endswith(".py") and name.count(".") == 1:
-            yield DiscoveryResult.Module(name[:-3], os.path.join(directory, name))
+        if (name.endswith(".py") or name.endswith(".pyi")) and name.count(".") == 1:
+            stem = name[:-4] if name.endswith(".pyi") else name[:-3]
+            yield DiscoveryResult.Module(stem, os.path.join(directory, name))
         else:
             full_path = os.path.join(directory, name, "__init__.py")
             if os.path.isfile(full_path):

--- a/docspec-python/src/docspec_python/__init__.py
+++ b/docspec-python/src/docspec_python/__init__.py
@@ -191,7 +191,10 @@ def iter_package_files(
             continue
         for item in recurse_directory(parent_dir):
             if item.suffix in (".py", ".pyi"):
-                parts = item.with_suffix("").relative_to(parent_dir).parts
+                # Use item.stem to correctly strip both .py and .pyi suffixes.
+                # item.with_suffix("") would turn foo.pyi into foo.py, not foo.
+                stem_path = item.parent / item.stem
+                parts = stem_path.relative_to(parent_dir).parts
                 if parts[-1] == "__init__":
                     parts = parts[:-1]
                 module_name = ".".join((package_name,) + parts)
@@ -240,7 +243,8 @@ def discover(directory: t.Union[str, Path]) -> t.Iterable[DiscoveryResult]:
             yield DiscoveryResult.Module(stem, os.path.join(directory, name))
         else:
             full_path = os.path.join(directory, name, "__init__.py")
-            if os.path.isfile(full_path):
+            full_path_pyi = os.path.join(directory, name, "__init__.pyi")
+            if os.path.isfile(full_path) or os.path.isfile(full_path_pyi):
                 yield DiscoveryResult.Package(name, os.path.join(directory, name))
 
 


### PR DESCRIPTION
## Summary
Adds support for `.pyi` type stub files alongside `.py` files in two places:

- `iter_package_files()`: now yields `.pyi` files in addition to `.py` files
- `discover()`: now discovers `.pyi` modules, correctly stripping the 4-char suffix

## Motivation
Closes NiklasRosenstein/pydoc-markdown#316

Users with PyBind11 packages or packages that store docstrings in `.pyi` 
stub files were unable to generate documentation without manually renaming 
files. This change allows pydoc-markdown to work natively with `.pyi` files.

## Changes
- `iter_package_files`: `item.suffix == ".py"` → `item.suffix in (".py", ".pyi")`
- `discover`: added `.pyi` check and correct stem extraction using `name[:-4]`